### PR TITLE
Add Music Archiver WordPress plugin scaffolding

### DIFF
--- a/music-archiver/blocks/album-list/block.json
+++ b/music-archiver/blocks/album-list/block.json
@@ -1,0 +1,14 @@
+{
+  "apiVersion": 2,
+  "name": "music-archiver/album-list",
+  "title": "Music Archiver Album List",
+  "category": "widgets",
+  "icon": "album",
+  "textdomain": "music-archiver",
+  "attributes": {
+    "user": { "type": "string", "default": "me" },
+    "public": { "type": "boolean", "default": false }
+  },
+  "editorScript": "music-archiver-album-list-editor",
+  "style": "music-archiver"
+}

--- a/music-archiver/blocks/album-list/edit.js
+++ b/music-archiver/blocks/album-list/edit.js
@@ -1,0 +1,29 @@
+import { __ } from '@wordpress/i18n';
+import { InspectorControls } from '@wordpress/block-editor';
+import { PanelBody, TextControl, ToggleControl } from '@wordpress/components';
+
+export default function Edit( { attributes, setAttributes } ) {
+    const { user, public: isPublic } = attributes;
+
+    return (
+        <>
+            <InspectorControls>
+                <PanelBody title={ __( 'Album List Settings', 'music-archiver' ) }>
+                    <TextControl
+                        label={ __( 'User', 'music-archiver' ) }
+                        value={ user }
+                        onChange={ ( value ) => setAttributes( { user: value } ) }
+                    />
+                    <ToggleControl
+                        label={ __( 'Public albums only', 'music-archiver' ) }
+                        checked={ isPublic }
+                        onChange={ ( value ) => setAttributes( { public: value } ) }
+                    />
+                </PanelBody>
+            </InspectorControls>
+            <div className="ma-album-list-block">
+                <p>{ __( 'Music Archiver album list will render on the front end.', 'music-archiver' ) }</p>
+            </div>
+        </>
+    );
+}

--- a/music-archiver/blocks/album-list/save.js
+++ b/music-archiver/blocks/album-list/save.js
@@ -1,0 +1,3 @@
+export default function save() {
+    return null;
+}

--- a/music-archiver/blocks/album-list/style.css
+++ b/music-archiver/blocks/album-list/style.css
@@ -1,0 +1,4 @@
+.ma-album-list-block {
+    border: 1px dashed #ccd0d4;
+    padding: 12px;
+}

--- a/music-archiver/blocks/player/block.json
+++ b/music-archiver/blocks/player/block.json
@@ -1,0 +1,13 @@
+{
+  "apiVersion": 2,
+  "name": "music-archiver/player",
+  "title": "Music Archiver Player",
+  "category": "widgets",
+  "icon": "controls-play",
+  "textdomain": "music-archiver",
+  "attributes": {
+    "source": { "type": "string", "default": "" }
+  },
+  "editorScript": "music-archiver-player-editor",
+  "style": "music-archiver"
+}

--- a/music-archiver/blocks/player/edit.js
+++ b/music-archiver/blocks/player/edit.js
@@ -1,0 +1,23 @@
+import { __ } from '@wordpress/i18n';
+import { InspectorControls } from '@wordpress/block-editor';
+import { PanelBody, TextControl } from '@wordpress/components';
+
+export default function Edit( { attributes, setAttributes } ) {
+    const { source } = attributes;
+    return (
+        <>
+            <InspectorControls>
+                <PanelBody title={ __( 'Player Settings', 'music-archiver' ) }>
+                    <TextControl
+                        label={ __( 'Source (album:ID or playlist:ID)', 'music-archiver' ) }
+                        value={ source }
+                        onChange={ ( value ) => setAttributes( { source: value } ) }
+                    />
+                </PanelBody>
+            </InspectorControls>
+            <div className="ma-player-block">
+                <p>{ __( 'Music Archiver player will render on the front end.', 'music-archiver' ) }</p>
+            </div>
+        </>
+    );
+}

--- a/music-archiver/blocks/player/save.js
+++ b/music-archiver/blocks/player/save.js
@@ -1,0 +1,3 @@
+export default function save() {
+    return null;
+}

--- a/music-archiver/blocks/player/style.css
+++ b/music-archiver/blocks/player/style.css
@@ -1,0 +1,4 @@
+.ma-player-block {
+    border: 1px dashed #ccd0d4;
+    padding: 12px;
+}

--- a/music-archiver/blocks/playlist/block.json
+++ b/music-archiver/blocks/playlist/block.json
@@ -1,0 +1,10 @@
+{
+  "apiVersion": 2,
+  "name": "music-archiver/playlist",
+  "title": "Music Archiver Playlist",
+  "category": "widgets",
+  "icon": "playlist-audio",
+  "textdomain": "music-archiver",
+  "editorScript": "music-archiver-playlist-editor",
+  "style": "music-archiver"
+}

--- a/music-archiver/blocks/playlist/edit.js
+++ b/music-archiver/blocks/playlist/edit.js
@@ -1,0 +1,9 @@
+import { __ } from '@wordpress/i18n';
+
+export default function Edit() {
+    return (
+        <div className="ma-playlist-block">
+            <p>{ __( 'Music Archiver playlist will render on the front end.', 'music-archiver' ) }</p>
+        </div>
+    );
+}

--- a/music-archiver/blocks/playlist/save.js
+++ b/music-archiver/blocks/playlist/save.js
@@ -1,0 +1,3 @@
+export default function save() {
+    return null;
+}

--- a/music-archiver/blocks/playlist/style.css
+++ b/music-archiver/blocks/playlist/style.css
@@ -1,0 +1,4 @@
+.ma-playlist-block {
+    border: 1px dashed #ccd0d4;
+    padding: 12px;
+}

--- a/music-archiver/includes/class-activator.php
+++ b/music-archiver/includes/class-activator.php
@@ -1,0 +1,18 @@
+<?php
+namespace MA;
+
+defined( 'ABSPATH' ) || exit;
+
+class Activator {
+    public static function activate(): void {
+        require_once MA_PATH . 'includes/class-db.php';
+        require_once MA_PATH . 'includes/class-roles.php';
+
+        DB::maybe_create_tables();
+        Roles::register_roles();
+
+        if ( ! wp_next_scheduled( 'ma_drive_sync' ) ) {
+            wp_schedule_event( time() + HOUR_IN_SECONDS, 'hourly', 'ma_drive_sync' );
+        }
+    }
+}

--- a/music-archiver/includes/class-admin-ui.php
+++ b/music-archiver/includes/class-admin-ui.php
@@ -1,0 +1,58 @@
+<?php
+namespace MA;
+
+defined( 'ABSPATH' ) || exit;
+
+class Admin_UI {
+    public static function register_menu(): void {
+        add_menu_page(
+            __( 'Music Archiver', 'music-archiver' ),
+            __( 'Music Archiver', 'music-archiver' ),
+            'ma_manage',
+            'music-archiver',
+            [ self::class, 'render_page' ],
+            'dashicons-album',
+            56
+        );
+    }
+
+    public static function render_page(): void {
+        if ( ! current_user_can_manage() ) {
+            wp_die( esc_html__( 'You do not have permission to access this page.', 'music-archiver' ) );
+        }
+
+        $settings = get_settings();
+        ?>
+        <div class="wrap ma-admin">
+            <h1><?php esc_html_e( 'Music Archiver Settings', 'music-archiver' ); ?></h1>
+            <form action="options.php" method="post">
+                <?php
+                settings_fields( 'ma_settings' );
+                wp_nonce_field( 'ma_admin_save', 'ma_admin_nonce' );
+                ?>
+                <div class="ma-settings">
+                    <div class="ma-card">
+                        <h2><?php esc_html_e( 'General', 'music-archiver' ); ?></h2>
+                        <?php do_settings_fields( 'ma_settings', 'ma_general' ); ?>
+                    </div>
+                    <div class="ma-card">
+                        <h2><?php esc_html_e( 'Premium', 'music-archiver' ); ?></h2>
+                        <p class="description"><?php esc_html_e( 'Configure how premium access is granted.', 'music-archiver' ); ?></p>
+                        <?php do_settings_fields( 'ma_settings', 'ma_premium' ); ?>
+                    </div>
+                    <div class="ma-card">
+                        <h2><?php esc_html_e( 'Google Drive', 'music-archiver' ); ?></h2>
+                        <p class="description"><?php esc_html_e( 'Provide OAuth credentials. Use the redirect URI when configuring the consent screen.', 'music-archiver' ); ?></p>
+                        <?php do_settings_fields( 'ma_settings', 'ma_drive' ); ?>
+                    </div>
+                    <div class="ma-card">
+                        <h2><?php esc_html_e( 'Player', 'music-archiver' ); ?></h2>
+                        <?php do_settings_fields( 'ma_settings', 'ma_player' ); ?>
+                    </div>
+                </div>
+                <?php submit_button(); ?>
+            </form>
+        </div>
+        <?php
+    }
+}

--- a/music-archiver/includes/class-cpt.php
+++ b/music-archiver/includes/class-cpt.php
@@ -1,0 +1,30 @@
+<?php
+namespace MA;
+
+defined( 'ABSPATH' ) || exit;
+
+class CPT {
+    public static function register(): void {
+        register_post_type( 'ma_album', [
+            'labels' => [
+                'name'          => __( 'Albums', 'music-archiver' ),
+                'singular_name' => __( 'Album', 'music-archiver' ),
+            ],
+            'public'       => true,
+            'show_in_menu' => false,
+            'rewrite'      => [ 'slug' => 'album' ],
+            'supports'     => [ 'title', 'editor', 'thumbnail', 'author' ],
+        ] );
+
+        register_post_type( 'ma_track', [
+            'labels' => [
+                'name'          => __( 'Tracks', 'music-archiver' ),
+                'singular_name' => __( 'Track', 'music-archiver' ),
+            ],
+            'public'       => true,
+            'show_in_menu' => false,
+            'rewrite'      => [ 'slug' => 'track' ],
+            'supports'     => [ 'title', 'editor', 'thumbnail', 'author' ],
+        ] );
+    }
+}

--- a/music-archiver/includes/class-db.php
+++ b/music-archiver/includes/class-db.php
@@ -1,0 +1,136 @@
+<?php
+namespace MA;
+
+defined( 'ABSPATH' ) || exit;
+
+class DB {
+    public static function maybe_create_tables(): void {
+        global $wpdb;
+
+        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+
+        $charset_collate = $wpdb->get_charset_collate();
+
+        $tables = [];
+        $tables[] = "CREATE TABLE {$wpdb->prefix}ma_albums (
+            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            user_id BIGINT UNSIGNED NOT NULL,
+            name VARCHAR(255) NOT NULL,
+            description TEXT NULL,
+            cover_id BIGINT UNSIGNED NULL,
+            is_public TINYINT(1) DEFAULT 0,
+            created_at DATETIME NOT NULL,
+            updated_at DATETIME NOT NULL,
+            PRIMARY KEY  (id),
+            KEY user_id (user_id),
+            KEY is_public (is_public)
+        ) {$charset_collate};";
+
+        $tables[] = "CREATE TABLE {$wpdb->prefix}ma_tracks (
+            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            user_id BIGINT UNSIGNED NOT NULL,
+            title VARCHAR(255) NOT NULL,
+            source_url TEXT NULL,
+            attachment_id BIGINT UNSIGNED NULL,
+            duration_sec INT NULL,
+            created_at DATETIME NOT NULL,
+            PRIMARY KEY  (id),
+            KEY user_id (user_id),
+            KEY title (title)
+        ) {$charset_collate};";
+
+        $tables[] = "CREATE TABLE {$wpdb->prefix}ma_album_track (
+            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            album_id BIGINT UNSIGNED NOT NULL,
+            track_id BIGINT UNSIGNED NOT NULL,
+            position INT NOT NULL DEFAULT 0,
+            PRIMARY KEY  (id),
+            UNIQUE KEY album_track (album_id, track_id),
+            KEY album_position (album_id, position)
+        ) {$charset_collate};";
+
+        $tables[] = "CREATE TABLE {$wpdb->prefix}ma_playlists (
+            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            user_id BIGINT UNSIGNED NOT NULL,
+            name VARCHAR(255) NOT NULL DEFAULT 'My Playlist',
+            created_at DATETIME NOT NULL,
+            PRIMARY KEY (id),
+            UNIQUE KEY user_name (user_id, name),
+            KEY user_id (user_id)
+        ) {$charset_collate};";
+
+        $tables[] = "CREATE TABLE {$wpdb->prefix}ma_playlist_items (
+            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            playlist_id BIGINT UNSIGNED NOT NULL,
+            track_id BIGINT UNSIGNED NOT NULL,
+            position INT NOT NULL DEFAULT 0,
+            PRIMARY KEY (id),
+            KEY playlist_position (playlist_id, position)
+        ) {$charset_collate};";
+
+        $tables[] = "CREATE TABLE {$wpdb->prefix}ma_ratings (
+            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            user_id BIGINT UNSIGNED NOT NULL,
+            object_type ENUM('album','track') NOT NULL,
+            object_id BIGINT UNSIGNED NOT NULL,
+            stars TINYINT NOT NULL,
+            created_at DATETIME NOT NULL,
+            PRIMARY KEY (id),
+            UNIQUE KEY user_object (user_id, object_type, object_id),
+            KEY object_lookup (object_type, object_id)
+        ) {$charset_collate};";
+
+        $tables[] = "CREATE TABLE {$wpdb->prefix}ma_favourites (
+            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            user_id BIGINT UNSIGNED NOT NULL,
+            object_type ENUM('album','track') NOT NULL,
+            object_id BIGINT UNSIGNED NOT NULL,
+            created_at DATETIME NOT NULL,
+            PRIMARY KEY (id),
+            UNIQUE KEY user_object (user_id, object_type, object_id)
+        ) {$charset_collate};";
+
+        $tables[] = "CREATE TABLE {$wpdb->prefix}ma_drive_accounts (
+            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            user_id BIGINT UNSIGNED NOT NULL,
+            provider VARCHAR(32) NOT NULL DEFAULT 'gdrive',
+            label VARCHAR(120) NOT NULL,
+            token_json LONGTEXT NULL,
+            created_at DATETIME NOT NULL,
+            PRIMARY KEY (id),
+            UNIQUE KEY user_provider (user_id, provider)
+        ) {$charset_collate};";
+
+        $tables[] = "CREATE TABLE {$wpdb->prefix}ma_drive_links (
+            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            album_id BIGINT UNSIGNED NOT NULL,
+            drive_folder_id VARCHAR(128) NOT NULL,
+            last_synced_at DATETIME NULL,
+            PRIMARY KEY (id),
+            UNIQUE KEY album (album_id)
+        ) {$charset_collate};";
+
+        foreach ( $tables as $sql ) {
+            dbDelta( $sql );
+        }
+    }
+
+    public static function maybe_drop_tables(): void {
+        global $wpdb;
+        $tables = [
+            'ma_album_track',
+            'ma_playlist_items',
+            'ma_playlists',
+            'ma_ratings',
+            'ma_favourites',
+            'ma_drive_links',
+            'ma_drive_accounts',
+            'ma_tracks',
+            'ma_albums',
+        ];
+
+        foreach ( $tables as $table ) {
+            $wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}{$table}" );
+        }
+    }
+}

--- a/music-archiver/includes/class-deactivator.php
+++ b/music-archiver/includes/class-deactivator.php
@@ -1,0 +1,13 @@
+<?php
+namespace MA;
+
+defined( 'ABSPATH' ) || exit;
+
+class Deactivator {
+    public static function deactivate(): void {
+        $timestamp = wp_next_scheduled( 'ma_drive_sync' );
+        if ( $timestamp ) {
+            wp_unschedule_event( $timestamp, 'ma_drive_sync' );
+        }
+    }
+}

--- a/music-archiver/includes/class-google-drive.php
+++ b/music-archiver/includes/class-google-drive.php
@@ -1,0 +1,209 @@
+<?php
+namespace MA;
+
+defined( 'ABSPATH' ) || exit;
+
+class Google_Drive {
+    public static function init(): void {
+        add_action( 'rest_api_init', [ self::class, 'register_routes' ] );
+        add_action( 'ma_drive_sync', [ self::class, 'cron_sync' ] );
+    }
+
+    public static function register_routes(): void {
+        register_rest_route( 'ma/v1', '/drive/auth-url', [
+            'methods'             => 'GET',
+            'callback'            => [ self::class, 'rest_auth_url' ],
+            'permission_callback' => function () {
+                return is_user_logged_in();
+            },
+        ] );
+
+        register_rest_route( 'ma/v1', '/drive/callback', [
+            'methods'             => 'POST',
+            'callback'            => [ self::class, 'rest_callback' ],
+            'permission_callback' => '__return_true',
+        ] );
+
+        register_rest_route( 'ma/v1', '/drive/link', [
+            'methods'             => 'POST',
+            'callback'            => [ self::class, 'rest_link_album' ],
+            'permission_callback' => function () {
+                return is_user_logged_in();
+            },
+        ] );
+
+        register_rest_route( 'ma/v1', '/drive/sync/(?P<album>\d+)', [
+            'methods'             => 'POST',
+            'callback'            => [ self::class, 'rest_sync_album' ],
+            'permission_callback' => function () {
+                return is_user_logged_in();
+            },
+        ] );
+    }
+
+    public static function rest_auth_url( \WP_REST_Request $request ) {
+        $settings = get_settings();
+        if ( empty( $settings['gdrive_client_id'] ) ) {
+            return rest_error( __( 'Google Drive is not configured.', 'music-archiver' ), 400 );
+        }
+
+        $state = wp_generate_password( 32, false );
+        update_user_meta( get_current_user_id(), 'ma_drive_state', $state );
+
+        $redirect_uri = urlencode( $settings['gdrive_redirect_uri'] );
+        $url          = sprintf(
+            'https://accounts.google.com/o/oauth2/v2/auth?response_type=code&client_id=%s&redirect_uri=%s&scope=%s&access_type=offline&prompt=consent&state=%s',
+            rawurlencode( $settings['gdrive_client_id'] ),
+            $redirect_uri,
+            rawurlencode( 'https://www.googleapis.com/auth/drive.readonly' ),
+            rawurlencode( $state )
+        );
+
+        return rest_success( [ 'url' => $url ] );
+    }
+
+    public static function rest_callback( \WP_REST_Request $request ) {
+        $code  = sanitize_text_field( $request['code'] ?? '' );
+        $state = sanitize_text_field( $request['state'] ?? '' );
+        $user  = get_current_user_id();
+        if ( ! $user ) {
+            return rest_error( __( 'Authentication required.', 'music-archiver' ), 401 );
+        }
+
+        $expected = get_user_meta( $user, 'ma_drive_state', true );
+        if ( ! $expected || $expected !== $state ) {
+            return rest_error( __( 'Invalid OAuth state.', 'music-archiver' ), 400 );
+        }
+
+        $settings = get_settings();
+        $body = [
+            'code'          => $code,
+            'client_id'     => $settings['gdrive_client_id'],
+            'client_secret' => $settings['gdrive_client_secret'],
+            'redirect_uri'  => $settings['gdrive_redirect_uri'],
+            'grant_type'    => 'authorization_code',
+        ];
+
+        $response = wp_remote_post( 'https://oauth2.googleapis.com/token', [
+            'body'    => $body,
+            'timeout' => 20,
+        ] );
+
+        if ( is_wp_error( $response ) ) {
+            return rest_error( $response->get_error_message(), 400 );
+        }
+
+        $payload = json_decode( wp_remote_retrieve_body( $response ), true );
+        if ( empty( $payload['access_token'] ) ) {
+            return rest_error( __( 'OAuth exchange failed.', 'music-archiver' ), 400 );
+        }
+
+        global $wpdb;
+        $wpdb->replace(
+            $wpdb->prefix . 'ma_drive_accounts',
+            [
+                'user_id'    => $user,
+                'provider'   => 'gdrive',
+                'label'      => sprintf( __( 'Google Drive (%s)', 'music-archiver' ), wp_get_current_user()->user_login ),
+                'token_json' => encrypt_token( wp_json_encode( $payload ) ),
+                'created_at' => current_time( 'mysql' ),
+            ],
+            [ '%d', '%s', '%s', '%s', '%s' ]
+        );
+
+        delete_user_meta( $user, 'ma_drive_state' );
+
+        return rest_success( [ 'connected' => true ] );
+    }
+
+    public static function rest_link_album( \WP_REST_Request $request ) {
+        $album_id = (int) $request->get_param( 'album_id' );
+        $folder   = sanitize_text_field( $request->get_param( 'drive_folder_id' ) );
+        if ( ! $album_id || ! $folder ) {
+            return rest_error( __( 'Album and folder are required.', 'music-archiver' ) );
+        }
+
+        global $wpdb;
+        $wpdb->replace( $wpdb->prefix . 'ma_drive_links', [
+            'album_id'       => $album_id,
+            'drive_folder_id'=> $folder,
+            'last_synced_at' => current_time( 'mysql' ),
+        ], [ '%d', '%s', '%s' ] );
+
+        return rest_success( [ 'linked' => true ] );
+    }
+
+    public static function rest_sync_album( \WP_REST_Request $request ) {
+        $album_id = (int) $request['album'];
+        self::sync_album_tracks( $album_id );
+        return rest_success( [ 'synced' => true ] );
+    }
+
+    public static function cron_sync(): void {
+        global $wpdb;
+        $albums = $wpdb->get_col( "SELECT album_id FROM {$wpdb->prefix}ma_drive_links" );
+        foreach ( $albums as $album_id ) {
+            self::sync_album_tracks( (int) $album_id );
+        }
+    }
+
+    private static function sync_album_tracks( int $album_id ): void {
+        if ( ! $album_id ) {
+            return;
+        }
+
+        global $wpdb;
+        $link = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$wpdb->prefix}ma_drive_links WHERE album_id = %d", $album_id ) );
+        if ( ! $link ) {
+            return;
+        }
+
+        $album = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$wpdb->prefix}ma_albums WHERE id = %d", $album_id ) );
+        if ( ! $album ) {
+            return;
+        }
+
+        $account = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$wpdb->prefix}ma_drive_accounts WHERE user_id = %d", $album->user_id ) );
+        if ( ! $account ) {
+            return;
+        }
+
+        $token = decrypt_token( $account->token_json );
+        if ( ! $token ) {
+            return;
+        }
+
+        $token = json_decode( $token, true );
+        $access_token = $token['access_token'] ?? '';
+        if ( ! $access_token ) {
+            return;
+        }
+
+        $url = sprintf( 'https://www.googleapis.com/drive/v3/files?q=%s&fields=files(id,name,mimeType,webContentLink)', rawurlencode( sprintf( "'%s' in parents and mimeType contains 'audio/'", $link->drive_folder_id ) ) );
+        $response = wp_remote_get( $url, [ 'headers' => [ 'Authorization' => 'Bearer ' . $access_token ] ] );
+        if ( is_wp_error( $response ) ) {
+            return;
+        }
+        $payload = json_decode( wp_remote_retrieve_body( $response ), true );
+        if ( empty( $payload['files'] ) ) {
+            return;
+        }
+
+        foreach ( $payload['files'] as $index => $file ) {
+            if ( empty( $file['webContentLink'] ) ) {
+                continue;
+            }
+
+            $wpdb->replace( $wpdb->prefix . 'ma_tracks', [
+                'user_id'      => $album->user_id,
+                'title'        => sanitize_text_field( $file['name'] ),
+                'source_url'   => esc_url_raw( $file['webContentLink'] ),
+                'attachment_id'=> 0,
+                'duration_sec' => null,
+                'created_at'   => current_time( 'mysql' ),
+            ], [ '%d', '%s', '%s', '%d', '%d', '%s' ] );
+        }
+
+        $wpdb->update( $wpdb->prefix . 'ma_drive_links', [ 'last_synced_at' => current_time( 'mysql' ) ], [ 'album_id' => $album_id ], [ '%s' ], [ '%d' ] );
+    }
+}

--- a/music-archiver/includes/class-player.php
+++ b/music-archiver/includes/class-player.php
@@ -1,0 +1,118 @@
+<?php
+namespace MA;
+
+defined( 'ABSPATH' ) || exit;
+
+class Player {
+    public static function register_shortcodes(): void {
+        add_shortcode( 'ma_album_list', [ self::class, 'shortcode_album_list' ] );
+        add_shortcode( 'ma_playlist', [ self::class, 'shortcode_playlist' ] );
+        add_shortcode( 'ma_player', [ self::class, 'shortcode_player' ] );
+        add_shortcode( 'ma_ratings', [ self::class, 'shortcode_ratings' ] );
+        add_shortcode( 'ma_favourites', [ self::class, 'shortcode_favourites' ] );
+    }
+
+    public static function register_assets(): void {
+        wp_register_style( 'music-archiver', MA_URL . 'public/css/music-archiver.css', [], MA_VERSION );
+        wp_register_script( 'ma-player', MA_URL . 'public/js/player.js', [ 'wp-api-fetch' ], MA_VERSION, true );
+        wp_register_script( 'ma-rating', MA_URL . 'public/js/rating.js', [ 'wp-api-fetch' ], MA_VERSION, true );
+        wp_register_script( 'ma-favourite', MA_URL . 'public/js/favourite.js', [ 'wp-api-fetch' ], MA_VERSION, true );
+        wp_register_script( 'ma-playlist', MA_URL . 'public/js/playlist.js', [ 'wp-api-fetch' ], MA_VERSION, true );
+        wp_register_script( 'ma-search', MA_URL . 'public/js/search.js', [ 'wp-api-fetch' ], MA_VERSION, true );
+
+        wp_register_script( 'music-archiver-album-list-editor', MA_URL . 'blocks/album-list/edit.js', [ 'wp-blocks', 'wp-element', 'wp-i18n', 'wp-components', 'wp-block-editor' ], MA_VERSION, true );
+        wp_register_script( 'music-archiver-playlist-editor', MA_URL . 'blocks/playlist/edit.js', [ 'wp-blocks', 'wp-element', 'wp-i18n' ], MA_VERSION, true );
+        wp_register_script( 'music-archiver-player-editor', MA_URL . 'blocks/player/edit.js', [ 'wp-blocks', 'wp-element', 'wp-i18n', 'wp-components', 'wp-block-editor' ], MA_VERSION, true );
+    }
+
+    public static function enqueue_public_assets(): void {
+        if ( ! is_singular() && ! has_block( 'music-archiver/player' ) && ! has_shortcode( get_post_field( 'post_content', get_the_ID() ), 'ma_player' ) ) {
+            return;
+        }
+
+        wp_enqueue_style( 'music-archiver' );
+        wp_enqueue_script( 'ma-player' );
+        wp_enqueue_script( 'ma-rating' );
+        wp_enqueue_script( 'ma-favourite' );
+        wp_enqueue_script( 'ma-playlist' );
+        wp_enqueue_script( 'ma-search' );
+
+        wp_localize_script( 'ma-player', 'MAPlayer', [
+            'restUrl' => esc_url_raw( rest_url( 'ma/v1/' ) ),
+            'nonce'   => wp_create_nonce( 'wp_rest' ),
+            'autoplay'=> (bool) get_settings()['player_autoplay'],
+            'shuffle' => (bool) get_settings()['player_shuffle'],
+        ] );
+    }
+
+    public static function enqueue_block_editor_assets(): void {
+        wp_enqueue_style( 'music-archiver' );
+    }
+
+    public static function shortcode_album_list( $atts ): string {
+        $atts = shortcode_atts( [
+            'user'   => 'me',
+            'public' => '0',
+        ], $atts, 'ma_album_list' );
+
+        ob_start();
+        $template = MA_PATH . 'templates/album-card.php';
+        if ( file_exists( $template ) ) {
+            $user_id = 'me' === $atts['user'] ? get_current_user_id() : (int) $atts['user'];
+            global $wpdb;
+            $query = "SELECT * FROM {$wpdb->prefix}ma_albums WHERE user_id = %d";
+            $public = (int) $atts['public'];
+            if ( $public ) {
+                $query .= ' AND is_public = 1';
+            }
+            $albums = $wpdb->get_results( $wpdb->prepare( $query, $user_id ), ARRAY_A );
+            include $template;
+        }
+
+        return ob_get_clean();
+    }
+
+    public static function shortcode_playlist(): string {
+        ob_start();
+        $template = MA_PATH . 'templates/playlist.php';
+        if ( file_exists( $template ) ) {
+            include $template;
+        }
+        return ob_get_clean();
+    }
+
+    public static function shortcode_player( $atts ): string {
+        $atts = shortcode_atts( [ 'source' => '' ], $atts, 'ma_player' );
+        ob_start();
+        $template = MA_PATH . 'templates/player.php';
+        if ( file_exists( $template ) ) {
+            $source = $atts['source'];
+            include $template;
+        }
+        return ob_get_clean();
+    }
+
+    public static function shortcode_ratings( $atts ): string {
+        $atts = shortcode_atts( [ 'object' => 'album', 'id' => 0 ], $atts, 'ma_ratings' );
+        ob_start();
+        $template = MA_PATH . 'templates/ratings.php';
+        if ( file_exists( $template ) ) {
+            $object = $atts['object'];
+            $id     = (int) $atts['id'];
+            include $template;
+        }
+        return ob_get_clean();
+    }
+
+    public static function shortcode_favourites( $atts ): string {
+        $atts = shortcode_atts( [ 'object' => 'album', 'id' => 0 ], $atts, 'ma_favourites' );
+        ob_start();
+        $template = MA_PATH . 'templates/favourites.php';
+        if ( file_exists( $template ) ) {
+            $object = $atts['object'];
+            $id     = (int) $atts['id'];
+            include $template;
+        }
+        return ob_get_clean();
+    }
+}

--- a/music-archiver/includes/class-plugin.php
+++ b/music-archiver/includes/class-plugin.php
@@ -1,0 +1,120 @@
+<?php
+namespace MA;
+
+defined( 'ABSPATH' ) || exit;
+
+class Plugin {
+    public function init(): void {
+        require_once MA_PATH . 'includes/class-db.php';
+        require_once MA_PATH . 'includes/class-roles.php';
+        require_once MA_PATH . 'includes/class-cpt.php';
+        require_once MA_PATH . 'includes/class-rest.php';
+        require_once MA_PATH . 'includes/class-settings.php';
+        require_once MA_PATH . 'includes/class-admin-ui.php';
+        require_once MA_PATH . 'includes/class-player.php';
+        require_once MA_PATH . 'includes/class-google-drive.php';
+        require_once MA_PATH . 'includes/class-premium.php';
+
+        add_action( 'init', [ DB::class, 'maybe_create_tables' ] );
+        add_action( 'init', [ Roles::class, 'register_roles' ] );
+        add_action( 'init', [ CPT::class, 'register' ] );
+        add_action( 'init', [ $this, 'register_blocks' ] );
+        add_action( 'init', [ Player::class, 'register_shortcodes' ] );
+        add_action( 'init', [ Player::class, 'register_assets' ] );
+
+        add_action( 'admin_init', [ Settings::class, 'register' ] );
+        add_action( 'admin_menu', [ Admin_UI::class, 'register_menu' ] );
+
+        add_action( 'rest_api_init', [ Rest::class, 'register_routes' ] );
+
+        add_action( 'plugins_loaded', [ Premium::class, 'init' ] );
+        add_action( 'plugins_loaded', [ Google_Drive::class, 'init' ] );
+
+        add_action( 'enqueue_block_editor_assets', [ Player::class, 'enqueue_block_editor_assets' ] );
+        add_action( 'wp_enqueue_scripts', [ Player::class, 'enqueue_public_assets' ] );
+
+        add_action( 'init', [ $this, 'register_privacy_exporters' ] );
+    }
+
+    public function register_blocks(): void {
+        if ( function_exists( 'register_block_type' ) ) {
+            register_block_type( MA_PATH . 'blocks/album-list' );
+            register_block_type( MA_PATH . 'blocks/playlist' );
+            register_block_type( MA_PATH . 'blocks/player' );
+        }
+    }
+
+    public function register_privacy_exporters(): void {
+        if ( ! function_exists( 'wp_register_personal_data_exporter' ) ) {
+            return;
+        }
+
+        $callback = [ $this, 'privacy_exporter' ];
+        $eraser   = [ $this, 'privacy_eraser' ];
+
+        wp_register_personal_data_exporter( 'music-archiver', __( 'Music Archiver Data', 'music-archiver' ), $callback );
+        wp_register_personal_data_eraser( 'music-archiver', __( 'Music Archiver Data', 'music-archiver' ), $eraser );
+    }
+
+    public function privacy_exporter( string $email, int $page = 1 ): array {
+        $user = get_user_by( 'email', $email );
+        if ( ! $user ) {
+            return [ 'data' => [], 'done' => true ];
+        }
+
+        global $wpdb;
+        $tables = [
+            'albums'      => $wpdb->prefix . 'ma_albums',
+            'tracks'      => $wpdb->prefix . 'ma_tracks',
+            'playlists'   => $wpdb->prefix . 'ma_playlists',
+            'ratings'     => $wpdb->prefix . 'ma_ratings',
+            'favourites'  => $wpdb->prefix . 'ma_favourites',
+            'drive_links' => $wpdb->prefix . 'ma_drive_links',
+        ];
+
+        $data = [];
+        foreach ( $tables as $label => $table ) {
+            $items = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$table} WHERE user_id = %d", $user->ID ), ARRAY_A );
+            if ( ! empty( $items ) ) {
+                $data[] = [
+                    'group_id'    => "ma_{$label}",
+                    'group_label' => ucfirst( $label ),
+                    'item_id'     => "ma_{$label}_{$user->ID}",
+                    'data'        => array_map( static fn( $item ) => [
+                        'name'  => sprintf( __( '%s data', 'music-archiver' ), ucfirst( $label ) ),
+                        'value' => wp_json_encode( $item ),
+                    ], $items ),
+                ];
+            }
+        }
+
+        return [ 'data' => $data, 'done' => true ];
+    }
+
+    public function privacy_eraser( string $email, int $page = 1 ): array {
+        $user = get_user_by( 'email', $email );
+        if ( ! $user ) {
+            return [ 'items_removed' => false, 'items_retained' => false, 'messages' => [], 'done' => true ];
+        }
+
+        global $wpdb;
+        $tables = [
+            $wpdb->prefix . 'ma_albums',
+            $wpdb->prefix . 'ma_tracks',
+            $wpdb->prefix . 'ma_playlists',
+            $wpdb->prefix . 'ma_playlist_items',
+            $wpdb->prefix . 'ma_ratings',
+            $wpdb->prefix . 'ma_favourites',
+            $wpdb->prefix . 'ma_drive_accounts',
+            $wpdb->prefix . 'ma_drive_links',
+        ];
+
+        foreach ( $tables as $table ) {
+            $wpdb->delete( $table, [ 'user_id' => $user->ID ], [ '%d' ] );
+        }
+
+        delete_user_meta( $user->ID, 'ma_is_premium' );
+
+        return [ 'items_removed' => true, 'items_retained' => false, 'messages' => [], 'done' => true ];
+    }
+}

--- a/music-archiver/includes/class-premium.php
+++ b/music-archiver/includes/class-premium.php
@@ -1,0 +1,132 @@
+<?php
+namespace MA;
+
+defined( 'ABSPATH' ) || exit;
+
+class Premium {
+    public static function init(): void {
+        add_action( 'rest_api_init', [ self::class, 'register_routes' ] );
+        add_action( 'woocommerce_order_status_completed', [ self::class, 'handle_wc_complete' ] );
+    }
+
+    public static function register_routes(): void {
+        register_rest_route( 'ma/v1', '/limits', [
+            'methods'             => 'GET',
+            'callback'            => [ self::class, 'rest_limits' ],
+            'permission_callback' => '__return_true',
+        ] );
+
+        register_rest_route( 'ma/v1', '/premium/status', [
+            'methods'             => 'GET',
+            'callback'            => [ self::class, 'rest_status' ],
+            'permission_callback' => function () {
+                return is_user_logged_in();
+            },
+        ] );
+
+        register_rest_route( 'ma/v1', '/premium/stripe/session', [
+            'methods'             => 'POST',
+            'callback'            => [ self::class, 'rest_stripe_session' ],
+            'permission_callback' => function () {
+                return is_user_logged_in();
+            },
+        ] );
+
+        register_rest_route( 'ma/v1', '/stripe/webhook', [
+            'methods'             => 'POST',
+            'callback'            => [ self::class, 'rest_stripe_webhook' ],
+            'permission_callback' => '__return_true',
+        ] );
+    }
+
+    public static function rest_limits(): \WP_REST_Response {
+        return rest_success( [ 'free' => get_free_limits() ] );
+    }
+
+    public static function rest_status(): \WP_REST_Response {
+        $user_id = get_current_user_id();
+        return rest_success( [ 'is_premium' => self::is_premium( $user_id ) ] );
+    }
+
+    public static function rest_stripe_session( \WP_REST_Request $request ) {
+        $settings = get_settings();
+        if ( 'stripe' !== $settings['premium_mode'] ) {
+            return rest_error( __( 'Stripe mode is disabled.', 'music-archiver' ), 400 );
+        }
+
+        if ( empty( $settings['stripe_secret'] ) || empty( $settings['stripe_price_id'] ) ) {
+            return rest_error( __( 'Stripe is not configured.', 'music-archiver' ), 400 );
+        }
+
+        $body = [
+            'success_url' => esc_url_raw( add_query_arg( 'ma_stripe_success', '1', home_url() ) ),
+            'cancel_url'  => esc_url_raw( add_query_arg( 'ma_stripe_cancel', '1', home_url() ) ),
+            'mode'        => 'subscription',
+            'line_items'  => [
+                [ 'price' => $settings['stripe_price_id'], 'quantity' => 1 ],
+            ],
+            'client_reference_id' => get_current_user_id(),
+        ];
+
+        $response = wp_remote_post( 'https://api.stripe.com/v1/checkout/sessions', [
+            'body'    => $body,
+            'headers' => [ 'Authorization' => 'Bearer ' . $settings['stripe_secret'] ],
+        ] );
+
+        if ( is_wp_error( $response ) ) {
+            return rest_error( $response->get_error_message(), 400 );
+        }
+
+        $payload = json_decode( wp_remote_retrieve_body( $response ), true );
+        if ( empty( $payload['url'] ) ) {
+            return rest_error( __( 'Unable to create session.', 'music-archiver' ), 400 );
+        }
+
+        return rest_success( [ 'url' => esc_url_raw( $payload['url'] ) ] );
+    }
+
+    public static function rest_stripe_webhook( \WP_REST_Request $request ) {
+        $body = $request->get_body();
+        $payload = json_decode( $body, true );
+        if ( empty( $payload['type'] ) ) {
+            return rest_error( __( 'Invalid webhook.', 'music-archiver' ), 400 );
+        }
+
+        if ( 'checkout.session.completed' === $payload['type'] && ! empty( $payload['data']['object']['client_reference_id'] ) ) {
+            $user_id = (int) $payload['data']['object']['client_reference_id'];
+            update_user_meta( $user_id, 'ma_is_premium', 1 );
+        }
+
+        return rest_success( [ 'received' => true ] );
+    }
+
+    public static function handle_wc_complete( $order_id ): void {
+        $settings = get_settings();
+        if ( 'woocommerce' !== $settings['premium_mode'] || empty( $settings['premium_product'] ) ) {
+            return;
+        }
+
+        if ( ! function_exists( 'wc_get_order' ) ) {
+            return;
+        }
+
+        $order = wc_get_order( $order_id );
+        if ( ! $order ) {
+            return;
+        }
+
+        foreach ( $order->get_items() as $item ) {
+            if ( (int) $item->get_product_id() === (int) $settings['premium_product'] ) {
+                update_user_meta( $order->get_user_id(), 'ma_is_premium', 1 );
+            }
+        }
+    }
+
+    public static function is_premium( int $user_id ): bool {
+        if ( ! $user_id ) {
+            return false;
+        }
+
+        return (bool) get_user_meta( $user_id, 'ma_is_premium', true );
+    }
+}

--- a/music-archiver/includes/class-rest.php
+++ b/music-archiver/includes/class-rest.php
@@ -1,0 +1,420 @@
+<?php
+namespace MA;
+
+defined( 'ABSPATH' ) || exit;
+
+class Rest {
+    public static function register_routes(): void {
+        $namespace = 'ma/v1';
+
+        register_rest_route( $namespace, '/albums', [
+            [
+                'methods'             => 'GET',
+                'callback'            => [ self::class, 'get_albums' ],
+                'permission_callback' => function () {
+                    return is_user_logged_in();
+                },
+            ],
+            [
+                'methods'             => 'POST',
+                'callback'            => [ self::class, 'create_album' ],
+                'permission_callback' => function () {
+                    return is_user_logged_in();
+                },
+            ],
+        ] );
+
+        register_rest_route( $namespace, '/albums/(?P<id>\d+)', [
+            'methods'             => [ 'GET', 'PATCH', 'DELETE' ],
+            'callback'            => [ self::class, 'album_detail' ],
+            'permission_callback' => function () {
+                return is_user_logged_in();
+            },
+            'args' => [
+                'id' => [ 'validate_callback' => 'is_numeric' ],
+            ],
+        ] );
+
+        register_rest_route( $namespace, '/albums/(?P<id>\d+)/tracks', [
+            [
+                'methods'             => 'GET',
+                'callback'            => [ self::class, 'get_album_tracks' ],
+                'permission_callback' => function () {
+                    return is_user_logged_in();
+                },
+            ],
+            [
+                'methods'             => 'POST',
+                'callback'            => [ self::class, 'add_album_track' ],
+                'permission_callback' => function () {
+                    return is_user_logged_in();
+                },
+            ],
+        ] );
+
+        register_rest_route( $namespace, '/albums/(?P<id>\d+)/order', [
+            'methods'             => 'PATCH',
+            'callback'            => [ self::class, 'update_album_order' ],
+            'permission_callback' => function () {
+                return is_user_logged_in();
+            },
+        ] );
+
+        register_rest_route( $namespace, '/tracks/(?P<id>\d+)', [
+            'methods'             => [ 'GET', 'DELETE' ],
+            'callback'            => [ self::class, 'track_detail' ],
+            'permission_callback' => function () {
+                return is_user_logged_in();
+            },
+        ] );
+
+        register_rest_route( $namespace, '/ratings', [
+            'methods'             => 'POST',
+            'callback'            => [ self::class, 'submit_rating' ],
+            'permission_callback' => function () {
+                return is_user_logged_in();
+            },
+        ] );
+
+        register_rest_route( $namespace, '/favourites/toggle', [
+            'methods'             => 'POST',
+            'callback'            => [ self::class, 'toggle_favourite' ],
+            'permission_callback' => function () {
+                return is_user_logged_in();
+            },
+        ] );
+
+        register_rest_route( $namespace, '/playlist', [
+            'methods'             => 'GET',
+            'callback'            => [ self::class, 'get_playlist' ],
+            'permission_callback' => function () {
+                return is_user_logged_in();
+            },
+        ] );
+
+        register_rest_route( $namespace, '/playlist/items', [
+            'methods'             => 'POST',
+            'callback'            => [ self::class, 'add_playlist_item' ],
+            'permission_callback' => function () {
+                return is_user_logged_in();
+            },
+        ] );
+
+        register_rest_route( $namespace, '/playlist/order', [
+            'methods'             => 'PATCH',
+            'callback'            => [ self::class, 'update_playlist_order' ],
+            'permission_callback' => function () {
+                return is_user_logged_in();
+            },
+        ] );
+
+        register_rest_route( $namespace, '/playlist/items/(?P<id>\d+)', [
+            'methods'             => 'DELETE',
+            'callback'            => [ self::class, 'delete_playlist_item' ],
+            'permission_callback' => function () {
+                return is_user_logged_in();
+            },
+        ] );
+
+        register_rest_route( $namespace, '/search', [
+            'methods'             => 'GET',
+            'callback'            => [ self::class, 'search' ],
+            'permission_callback' => function () {
+                return is_user_logged_in();
+            },
+        ] );
+
+        register_rest_route( $namespace, '/player/queue', [
+            'methods'             => 'GET',
+            'callback'            => [ self::class, 'player_queue' ],
+            'permission_callback' => function () {
+                return is_user_logged_in();
+            },
+        ] );
+    }
+
+    public static function get_albums( \WP_REST_Request $request ) {
+        global $wpdb;
+        $albums = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$wpdb->prefix}ma_albums WHERE user_id = %d", get_current_user_id() ), ARRAY_A );
+        return rest_success( [ 'albums' => $albums ] );
+    }
+
+    public static function create_album( \WP_REST_Request $request ) {
+        $limits = get_free_limits();
+        $user   = get_current_user_id();
+        if ( ! Premium::is_premium( $user ) ) {
+            global $wpdb;
+            $count = (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM {$wpdb->prefix}ma_albums WHERE user_id = %d", $user ) );
+            if ( $count >= (int) $limits['albums'] ) {
+                return rest_error( __( 'Album limit reached.', 'music-archiver' ), 403 );
+            }
+        }
+
+        $name        = sanitize_text_field( $request->get_param( 'name' ) );
+        $description = wp_kses_post( $request->get_param( 'description' ) );
+        $public      = (int) $request->get_param( 'is_public' );
+
+        global $wpdb;
+        $wpdb->insert( $wpdb->prefix . 'ma_albums', [
+            'user_id'    => $user,
+            'name'       => $name,
+            'description'=> $description,
+            'is_public'  => $public ? 1 : 0,
+            'created_at' => current_time( 'mysql' ),
+            'updated_at' => current_time( 'mysql' ),
+        ], [ '%d', '%s', '%s', '%d', '%s', '%s' ] );
+        $album_id = (int) $wpdb->insert_id;
+
+        do_action( 'ma_album_created', $album_id, $user );
+
+        return rest_success( [ 'id' => $album_id ], 201 );
+    }
+
+    public static function album_detail( \WP_REST_Request $request ) {
+        global $wpdb;
+        $id = (int) $request['id'];
+        $album = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$wpdb->prefix}ma_albums WHERE id = %d", $id ), ARRAY_A );
+        if ( ! $album || (int) $album['user_id'] !== get_current_user_id() ) {
+            return rest_error( __( 'Album not found.', 'music-archiver' ), 404 );
+        }
+
+        switch ( $request->get_method() ) {
+            case 'GET':
+                return rest_success( [ 'album' => $album ] );
+            case 'PATCH':
+                $params = $request->get_json_params();
+                $data   = [];
+                if ( isset( $params['name'] ) ) {
+                    $data['name'] = sanitize_text_field( $params['name'] );
+                }
+                if ( isset( $params['description'] ) ) {
+                    $data['description'] = wp_kses_post( $params['description'] );
+                }
+                if ( isset( $params['is_public'] ) ) {
+                    $data['is_public'] = (int) $params['is_public'];
+                }
+                if ( empty( $data ) ) {
+                    return rest_success( [ 'updated' => false ] );
+                }
+                $data['updated_at'] = current_time( 'mysql' );
+                $wpdb->update( $wpdb->prefix . 'ma_albums', $data, [ 'id' => $id ], null, [ '%d' ] );
+                return rest_success( [ 'updated' => true ] );
+            case 'DELETE':
+                $wpdb->delete( $wpdb->prefix . 'ma_albums', [ 'id' => $id ], [ '%d' ] );
+                return rest_success( [ 'deleted' => true ] );
+        }
+    }
+
+    public static function get_album_tracks( \WP_REST_Request $request ) {
+        global $wpdb;
+        $album_id = (int) $request['id'];
+        $tracks   = $wpdb->get_results( $wpdb->prepare( "SELECT t.*, at.position, at.id AS album_track_id FROM {$wpdb->prefix}ma_album_track at JOIN {$wpdb->prefix}ma_tracks t ON t.id = at.track_id WHERE at.album_id = %d ORDER BY at.position ASC", $album_id ), ARRAY_A );
+        return rest_success( [ 'tracks' => $tracks ] );
+    }
+
+    public static function add_album_track( \WP_REST_Request $request ) {
+        global $wpdb;
+        $album_id = (int) $request['id'];
+        $user_id  = get_current_user_id();
+
+        $album = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$wpdb->prefix}ma_albums WHERE id = %d", $album_id ) );
+        if ( ! $album || (int) $album->user_id !== $user_id ) {
+            return rest_error( __( 'Album not found.', 'music-archiver' ), 404 );
+        }
+
+        $limits = get_free_limits();
+        if ( ! Premium::is_premium( $user_id ) ) {
+            $count = (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM {$wpdb->prefix}ma_album_track WHERE album_id = %d", $album_id ) );
+            if ( $count >= (int) $limits['tracks_per_album'] ) {
+                return rest_error( __( 'Track limit reached.', 'music-archiver' ), 403 );
+            }
+        }
+
+        $title        = sanitize_text_field( $request->get_param( 'title' ) );
+        $source_url   = esc_url_raw( $request->get_param( 'source_url' ) );
+        $attachment_id = (int) $request->get_param( 'attachment_id' );
+
+        $wpdb->insert( $wpdb->prefix . 'ma_tracks', [
+            'user_id'      => $user_id,
+            'title'        => $title,
+            'source_url'   => $source_url,
+            'attachment_id'=> $attachment_id,
+            'duration_sec' => null,
+            'created_at'   => current_time( 'mysql' ),
+        ], [ '%d', '%s', '%s', '%d', '%d', '%s' ] );
+
+        $track_id = (int) $wpdb->insert_id;
+        $position = (int) $wpdb->get_var( $wpdb->prepare( "SELECT COALESCE(MAX(position),0) + 1 FROM {$wpdb->prefix}ma_album_track WHERE album_id = %d", $album_id ) );
+
+        $wpdb->insert( $wpdb->prefix . 'ma_album_track', [
+            'album_id' => $album_id,
+            'track_id' => $track_id,
+            'position' => $position,
+        ], [ '%d', '%d', '%d' ] );
+
+        do_action( 'ma_track_added', $track_id, $album_id );
+
+        return rest_success( [ 'track_id' => $track_id ], 201 );
+    }
+
+    public static function update_album_order( \WP_REST_Request $request ) {
+        global $wpdb;
+        $album_id = (int) $request['id'];
+        $items    = $request->get_json_params();
+        if ( ! is_array( $items ) ) {
+            return rest_error( __( 'Invalid payload.', 'music-archiver' ) );
+        }
+
+        foreach ( $items as $item ) {
+            if ( empty( $item['album_track_id'] ) || ! isset( $item['position'] ) ) {
+                continue;
+            }
+            $wpdb->update( $wpdb->prefix . 'ma_album_track', [ 'position' => (int) $item['position'] ], [ 'id' => (int) $item['album_track_id'] ], [ '%d' ], [ '%d' ] );
+        }
+
+        return rest_success( [ 'ordered' => true ] );
+    }
+
+    public static function track_detail( \WP_REST_Request $request ) {
+        global $wpdb;
+        $id = (int) $request['id'];
+        $track = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$wpdb->prefix}ma_tracks WHERE id = %d", $id ), ARRAY_A );
+        if ( ! $track || (int) $track['user_id'] !== get_current_user_id() ) {
+            return rest_error( __( 'Track not found.', 'music-archiver' ), 404 );
+        }
+
+        if ( 'GET' === $request->get_method() ) {
+            return rest_success( [ 'track' => $track ] );
+        }
+
+        $wpdb->delete( $wpdb->prefix . 'ma_tracks', [ 'id' => $id ], [ '%d' ] );
+        $wpdb->delete( $wpdb->prefix . 'ma_album_track', [ 'track_id' => $id ], [ '%d' ] );
+
+        return rest_success( [ 'deleted' => true ] );
+    }
+
+    public static function submit_rating( \WP_REST_Request $request ) {
+        global $wpdb;
+        $object_type = in_array( $request->get_param( 'object_type' ), [ 'album', 'track' ], true ) ? $request->get_param( 'object_type' ) : 'album';
+        $object_id   = (int) $request->get_param( 'object_id' );
+        $stars       = max( 1, min( 5, (int) $request->get_param( 'stars' ) ) );
+
+        $wpdb->replace( $wpdb->prefix . 'ma_ratings', [
+            'user_id'     => get_current_user_id(),
+            'object_type' => $object_type,
+            'object_id'   => $object_id,
+            'stars'       => $stars,
+            'created_at'  => current_time( 'mysql' ),
+        ], [ '%d', '%s', '%d', '%d', '%s' ] );
+
+        return rest_success( [ 'saved' => true ] );
+    }
+
+    public static function toggle_favourite( \WP_REST_Request $request ) {
+        global $wpdb;
+        $object_type = in_array( $request->get_param( 'object_type' ), [ 'album', 'track' ], true ) ? $request->get_param( 'object_type' ) : 'album';
+        $object_id   = (int) $request->get_param( 'object_id' );
+        $user_id     = get_current_user_id();
+
+        $existing = $wpdb->get_var( $wpdb->prepare( "SELECT id FROM {$wpdb->prefix}ma_favourites WHERE user_id = %d AND object_type = %s AND object_id = %d", $user_id, $object_type, $object_id ) );
+        if ( $existing ) {
+            $wpdb->delete( $wpdb->prefix . 'ma_favourites', [ 'id' => $existing ], [ '%d' ] );
+            return rest_success( [ 'favourited' => false ] );
+        }
+
+        $wpdb->insert( $wpdb->prefix . 'ma_favourites', [
+            'user_id'     => $user_id,
+            'object_type' => $object_type,
+            'object_id'   => $object_id,
+            'created_at'  => current_time( 'mysql' ),
+        ], [ '%d', '%s', '%d', '%s' ] );
+
+        return rest_success( [ 'favourited' => true ] );
+    }
+
+    public static function get_playlist(): \WP_REST_Response {
+        global $wpdb;
+        $user_id = get_current_user_id();
+        $playlist = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$wpdb->prefix}ma_playlists WHERE user_id = %d ORDER BY id ASC LIMIT 1", $user_id ) );
+        if ( ! $playlist ) {
+            $wpdb->insert( $wpdb->prefix . 'ma_playlists', [
+                'user_id'    => $user_id,
+                'name'       => __( 'My Playlist', 'music-archiver' ),
+                'created_at' => current_time( 'mysql' ),
+            ], [ '%d', '%s', '%s' ] );
+            $playlist = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$wpdb->prefix}ma_playlists WHERE user_id = %d ORDER BY id ASC LIMIT 1", $user_id ) );
+        }
+
+        $items = $wpdb->get_results( $wpdb->prepare( "SELECT pi.*, t.title, t.source_url FROM {$wpdb->prefix}ma_playlist_items pi JOIN {$wpdb->prefix}ma_tracks t ON t.id = pi.track_id WHERE pi.playlist_id = %d ORDER BY pi.position ASC", $playlist->id ), ARRAY_A );
+
+        return rest_success( [ 'playlist' => $playlist, 'items' => $items ] );
+    }
+
+    public static function add_playlist_item( \WP_REST_Request $request ) {
+        global $wpdb;
+        $track_id = (int) $request->get_param( 'track_id' );
+        $playlist = self::get_playlist()->get_data()['data']['playlist'] ?? null;
+        if ( ! $playlist ) {
+            return rest_error( __( 'Playlist not found.', 'music-archiver' ), 404 );
+        }
+
+        $position = (int) $wpdb->get_var( $wpdb->prepare( "SELECT COALESCE(MAX(position),0) + 1 FROM {$wpdb->prefix}ma_playlist_items WHERE playlist_id = %d", $playlist->id ) );
+        $wpdb->insert( $wpdb->prefix . 'ma_playlist_items', [
+            'playlist_id' => $playlist->id,
+            'track_id'    => $track_id,
+            'position'    => $position,
+        ], [ '%d', '%d', '%d' ] );
+
+        return rest_success( [ 'added' => true ] );
+    }
+
+    public static function update_playlist_order( \WP_REST_Request $request ) {
+        global $wpdb;
+        $items = $request->get_json_params();
+        if ( ! is_array( $items ) ) {
+            return rest_error( __( 'Invalid payload.', 'music-archiver' ) );
+        }
+
+        foreach ( $items as $item ) {
+            if ( empty( $item['id'] ) || ! isset( $item['position'] ) ) {
+                continue;
+            }
+            $wpdb->update( $wpdb->prefix . 'ma_playlist_items', [ 'position' => (int) $item['position'] ], [ 'id' => (int) $item['id'] ], [ '%d' ], [ '%d' ] );
+        }
+
+        return rest_success( [ 'ordered' => true ] );
+    }
+
+    public static function delete_playlist_item( \WP_REST_Request $request ) {
+        global $wpdb;
+        $id = (int) $request['id'];
+        $wpdb->delete( $wpdb->prefix . 'ma_playlist_items', [ 'id' => $id ], [ '%d' ] );
+        return rest_success( [ 'deleted' => true ] );
+    }
+
+    public static function search( \WP_REST_Request $request ) {
+        global $wpdb;
+        $term = '%' . $wpdb->esc_like( sanitize_text_field( $request->get_param( 'q' ) ) ) . '%';
+        $user = get_current_user_id();
+        $albums = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$wpdb->prefix}ma_albums WHERE user_id = %d AND name LIKE %s", $user, $term ), ARRAY_A );
+        $tracks = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$wpdb->prefix}ma_tracks WHERE user_id = %d AND title LIKE %s", $user, $term ), ARRAY_A );
+        return rest_success( [ 'albums' => $albums, 'tracks' => $tracks ] );
+    }
+
+    public static function player_queue( \WP_REST_Request $request ) {
+        $source = sanitize_text_field( $request->get_param( 'source' ) );
+        $queue  = [];
+        global $wpdb;
+
+        if ( str_starts_with( $source, 'album:' ) ) {
+            $album_id = (int) substr( $source, 6 );
+            $queue = $wpdb->get_results( $wpdb->prepare( "SELECT t.* FROM {$wpdb->prefix}ma_album_track at JOIN {$wpdb->prefix}ma_tracks t ON t.id = at.track_id WHERE at.album_id = %d ORDER BY at.position", $album_id ), ARRAY_A );
+        } elseif ( str_starts_with( $source, 'playlist:' ) ) {
+            $queue = $wpdb->get_results( $wpdb->prepare( "SELECT t.* FROM {$wpdb->prefix}ma_playlist_items pi JOIN {$wpdb->prefix}ma_tracks t ON t.id = pi.track_id WHERE pi.playlist_id = %d ORDER BY pi.position", (int) substr( $source, 9 ) ), ARRAY_A );
+        }
+
+        $queue = apply_filters( 'ma_player_queue', $queue, $source );
+
+        return rest_success( [ 'queue' => $queue ] );
+    }
+}

--- a/music-archiver/includes/class-roles.php
+++ b/music-archiver/includes/class-roles.php
@@ -1,0 +1,41 @@
+<?php
+namespace MA;
+
+defined( 'ABSPATH' ) || exit;
+
+class Roles {
+    public static function register_roles(): void {
+        $caps = self::get_capabilities();
+
+        add_role( 'music_archiver', __( 'Music Archiver', 'music-archiver' ), $caps['role'] );
+
+        $roles = [ 'subscriber', 'contributor', 'author', 'editor', 'administrator' ];
+        foreach ( $roles as $role_name ) {
+            $role = get_role( $role_name );
+            if ( ! $role ) {
+                continue;
+            }
+            foreach ( $caps['map'] as $cap ) {
+                $role->add_cap( $cap );
+            }
+        }
+    }
+
+    public static function remove_roles(): void {
+        remove_role( 'music_archiver' );
+    }
+
+    public static function get_capabilities(): array {
+        return [
+            'role' => [
+                'read'       => true,
+                'upload_files' => true,
+            ],
+            'map' => [
+                'ma_manage',
+                'ma_edit_own',
+                'ma_edit_public',
+            ],
+        ];
+    }
+}

--- a/music-archiver/includes/class-settings.php
+++ b/music-archiver/includes/class-settings.php
@@ -1,0 +1,94 @@
+<?php
+namespace MA;
+
+defined( 'ABSPATH' ) || exit;
+
+class Settings {
+    public static function register(): void {
+        register_setting( 'ma_settings', 'ma_settings', [ self::class, 'sanitize' ] );
+
+        add_settings_section( 'ma_general', __( 'General', 'music-archiver' ), '__return_false', 'ma_settings' );
+        add_settings_field( 'retain_data', __( 'Retain data on uninstall', 'music-archiver' ), [ self::class, 'field_checkbox' ], 'ma_settings', 'ma_general', [ 'key' => 'retain_data' ] );
+        add_settings_field( 'free_limits', __( 'Free plan limits', 'music-archiver' ), [ self::class, 'field_limits' ], 'ma_settings', 'ma_general' );
+
+        add_settings_section( 'ma_premium', __( 'Premium', 'music-archiver' ), '__return_false', 'ma_settings' );
+        add_settings_field( 'premium_mode', __( 'Premium Mode', 'music-archiver' ), [ self::class, 'field_select' ], 'ma_settings', 'ma_premium', [ 'key' => 'premium_mode', 'options' => [ 'stripe' => __( 'Stripe', 'music-archiver' ), 'woocommerce' => __( 'WooCommerce', 'music-archiver' ) ] ] );
+        add_settings_field( 'premium_product', __( 'WooCommerce Product ID', 'music-archiver' ), [ self::class, 'field_text' ], 'ma_settings', 'ma_premium', [ 'key' => 'premium_product' ] );
+        add_settings_field( 'stripe_price_id', __( 'Stripe Price ID', 'music-archiver' ), [ self::class, 'field_text' ], 'ma_settings', 'ma_premium', [ 'key' => 'stripe_price_id' ] );
+        add_settings_field( 'stripe_publishable', __( 'Stripe Publishable Key', 'music-archiver' ), [ self::class, 'field_text' ], 'ma_settings', 'ma_premium', [ 'key' => 'stripe_publishable' ] );
+        add_settings_field( 'stripe_secret', __( 'Stripe Secret Key', 'music-archiver' ), [ self::class, 'field_text' ], 'ma_settings', 'ma_premium', [ 'key' => 'stripe_secret' ] );
+
+        add_settings_section( 'ma_drive', __( 'Google Drive', 'music-archiver' ), '__return_false', 'ma_settings' );
+        add_settings_field( 'gdrive_client_id', __( 'Client ID', 'music-archiver' ), [ self::class, 'field_text' ], 'ma_settings', 'ma_drive', [ 'key' => 'gdrive_client_id' ] );
+        add_settings_field( 'gdrive_client_secret', __( 'Client Secret', 'music-archiver' ), [ self::class, 'field_text' ], 'ma_settings', 'ma_drive', [ 'key' => 'gdrive_client_secret' ] );
+        add_settings_field( 'gdrive_redirect_uri', __( 'Redirect URI', 'music-archiver' ), [ self::class, 'field_readonly' ], 'ma_settings', 'ma_drive', [ 'key' => 'gdrive_redirect_uri' ] );
+
+        add_settings_section( 'ma_player', __( 'Player', 'music-archiver' ), '__return_false', 'ma_settings' );
+        add_settings_field( 'player_autoplay', __( 'Autoplay', 'music-archiver' ), [ self::class, 'field_checkbox' ], 'ma_settings', 'ma_player', [ 'key' => 'player_autoplay' ] );
+        add_settings_field( 'player_shuffle', __( 'Default shuffle', 'music-archiver' ), [ self::class, 'field_checkbox' ], 'ma_settings', 'ma_player', [ 'key' => 'player_shuffle' ] );
+    }
+
+    public static function sanitize( array $input ): array {
+        $settings = get_settings();
+
+        $settings['retain_data']  = ! empty( $input['retain_data'] );
+        $settings['free_limits']  = [
+            'albums'           => isset( $input['free_limits']['albums'] ) ? max( 0, (int) $input['free_limits']['albums'] ) : 3,
+            'tracks_per_album' => isset( $input['free_limits']['tracks_per_album'] ) ? max( 0, (int) $input['free_limits']['tracks_per_album'] ) : 100,
+        ];
+        $settings['premium_mode'] = in_array( $input['premium_mode'] ?? 'stripe', [ 'stripe', 'woocommerce' ], true ) ? $input['premium_mode'] : 'stripe';
+        $settings['premium_product'] = sanitize_text_field( $input['premium_product'] ?? '' );
+        $settings['stripe_price_id'] = sanitize_text_field( $input['stripe_price_id'] ?? '' );
+        $settings['stripe_publishable'] = sanitize_text_field( $input['stripe_publishable'] ?? '' );
+        $settings['stripe_secret']      = sanitize_text_field( $input['stripe_secret'] ?? '' );
+        $settings['gdrive_client_id'] = sanitize_text_field( $input['gdrive_client_id'] ?? '' );
+        $settings['gdrive_client_secret'] = sanitize_text_field( $input['gdrive_client_secret'] ?? '' );
+        $settings['gdrive_redirect_uri']  = esc_url_raw( $settings['gdrive_redirect_uri'] );
+        $settings['player_autoplay'] = ! empty( $input['player_autoplay'] );
+        $settings['player_shuffle']  = ! empty( $input['player_shuffle'] );
+
+        return $settings;
+    }
+
+    public static function field_checkbox( array $args ): void {
+        $settings = get_settings();
+        $key      = $args['key'];
+        $value    = ! empty( $settings[ $key ] );
+        printf( '<label><input type="checkbox" name="ma_settings[%1$s]" value="1" %2$s /> %3$s</label>', esc_attr( $key ), checked( $value, true, false ), esc_html__( 'Enabled', 'music-archiver' ) );
+    }
+
+    public static function field_limits(): void {
+        $settings = get_settings();
+        $limits   = isset( $settings['free_limits'] ) ? (array) $settings['free_limits'] : [];
+        $albums   = isset( $limits['albums'] ) ? (int) $limits['albums'] : 3;
+        $tracks   = isset( $limits['tracks_per_album'] ) ? (int) $limits['tracks_per_album'] : 100;
+
+        printf( '<label>%s <input type="number" min="0" name="ma_settings[free_limits][albums]" value="%d" class="small-text" /></label><br/>', esc_html__( 'Albums', 'music-archiver' ), $albums );
+        printf( '<label>%s <input type="number" min="0" name="ma_settings[free_limits][tracks_per_album]" value="%d" class="small-text" /></label>', esc_html__( 'Tracks per album', 'music-archiver' ), $tracks );
+    }
+
+    public static function field_select( array $args ): void {
+        $settings = get_settings();
+        $key      = $args['key'];
+        $value    = $settings[ $key ] ?? '';
+        echo '<select name="ma_settings[' . esc_attr( $key ) . ']">';
+        foreach ( $args['options'] as $option_value => $label ) {
+            printf( '<option value="%1$s" %3$s>%2$s</option>', esc_attr( $option_value ), esc_html( $label ), selected( $value, $option_value, false ) );
+        }
+        echo '</select>';
+    }
+
+    public static function field_text( array $args ): void {
+        $settings = get_settings();
+        $key      = $args['key'];
+        $value    = esc_attr( $settings[ $key ] ?? '' );
+        printf( '<input type="text" class="regular-text" name="ma_settings[%1$s]" value="%2$s" />', esc_attr( $key ), $value );
+    }
+
+    public static function field_readonly( array $args ): void {
+        $settings = get_settings();
+        $key      = $args['key'];
+        $value    = esc_attr( $settings[ $key ] ?? '' );
+        printf( '<input type="text" readonly class="regular-text" value="%s" />', $value );
+    }
+}

--- a/music-archiver/includes/helpers.php
+++ b/music-archiver/includes/helpers.php
@@ -1,0 +1,124 @@
+<?php
+namespace MA;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Return the plugin option array with defaults.
+ */
+function get_settings(): array {
+    $defaults = [
+        'retain_data'       => false,
+        'free_limits'       => [ 'albums' => 3, 'tracks_per_album' => 100 ],
+        'premium_mode'      => 'stripe',
+        'premium_product'   => '',
+        'stripe_price_id'   => '',
+        'stripe_publishable'=> '',
+        'stripe_secret'     => '',
+        'gdrive_client_id'  => '',
+        'gdrive_client_secret' => '',
+        'gdrive_redirect_uri'  => rest_url( 'ma/v1/drive/callback' ),
+        'player_autoplay'      => false,
+        'player_shuffle'       => false,
+    ];
+
+    $settings = get_option( 'ma_settings', [] );
+
+    return wp_parse_args( $settings, $defaults );
+}
+
+/**
+ * Build REST response helper.
+ */
+function rest_success( $data = [], int $status = 200 ) {
+    return new \WP_REST_Response( [
+        'success' => true,
+        'data'    => $data,
+    ], $status );
+}
+
+function rest_error( string $message, int $status = 400 ) {
+    return new \WP_Error( 'ma_error', $message, [ 'status' => $status ] );
+}
+
+/**
+ * Retrieve encryption key for token storage.
+ */
+function get_secret_key(): string {
+    if ( defined( 'MA_SECRET_KEY' ) && MA_SECRET_KEY ) {
+        return (string) MA_SECRET_KEY;
+    }
+
+    $keys = [ 'AUTH_KEY', 'SECURE_AUTH_KEY', 'LOGGED_IN_KEY', 'NONCE_KEY' ];
+    foreach ( $keys as $constant ) {
+        if ( defined( $constant ) && constant( $constant ) ) {
+            return hash( 'sha256', constant( $constant ) );
+        }
+    }
+
+    return hash( 'sha256', get_site_url() . wp_salt() );
+}
+
+function encrypt_token( string $token ): string {
+    if ( ! function_exists( 'sodium_crypto_secretbox' ) ) {
+        return base64_encode( $token );
+    }
+
+    $key = sodium_crypto_secretbox_keygen();
+    $derived = substr( hash( 'sha256', get_secret_key(), true ), 0, SODIUM_CRYPTO_SECRETBOX_KEYBYTES );
+    $nonce = random_bytes( SODIUM_CRYPTO_SECRETBOX_NONCEBYTES );
+
+    $cipher = sodium_crypto_secretbox( $token, $nonce, $derived );
+
+    return wp_json_encode( [
+        'nonce' => base64_encode( $nonce ),
+        'data'  => base64_encode( $cipher ),
+    ] );
+}
+
+function decrypt_token( string $value ): ?string {
+    if ( ! $value ) {
+        return null;
+    }
+
+    if ( ! function_exists( 'sodium_crypto_secretbox_open' ) ) {
+        return base64_decode( $value );
+    }
+
+    $decoded = json_decode( $value, true );
+    if ( ! is_array( $decoded ) || empty( $decoded['nonce'] ) || empty( $decoded['data'] ) ) {
+        return null;
+    }
+
+    $nonce   = base64_decode( $decoded['nonce'] );
+    $cipher  = base64_decode( $decoded['data'] );
+    $derived = substr( hash( 'sha256', get_secret_key(), true ), 0, SODIUM_CRYPTO_SECRETBOX_KEYBYTES );
+
+    $plain = sodium_crypto_secretbox_open( $cipher, $nonce, $derived );
+
+    return false === $plain ? null : $plain;
+}
+
+function current_user_can_manage(): bool {
+    return current_user_can( 'ma_manage' ) || current_user_can( 'manage_options' );
+}
+
+function get_free_limits(): array {
+    $settings = get_settings();
+    $limits   = isset( $settings['free_limits'] ) && is_array( $settings['free_limits'] ) ? $settings['free_limits'] : [];
+    $limits   = wp_parse_args( $limits, [ 'albums' => 3, 'tracks_per_album' => 100 ] );
+
+    /**
+     * Filter the free plan limits.
+     */
+    return apply_filters( 'ma_free_limits', $limits );
+}
+
+function format_datetime( string $value ): string {
+    $timestamp = strtotime( $value );
+    if ( ! $timestamp ) {
+        return $value;
+    }
+
+    return wp_date( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $timestamp );
+}

--- a/music-archiver/languages/music-archiver.pot
+++ b/music-archiver/languages/music-archiver.pot
@@ -1,0 +1,7 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: Music Archiver 1.0.0\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: \n"

--- a/music-archiver/music-archiver.php
+++ b/music-archiver/music-archiver.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Plugin Name: Music Archiver
+ * Plugin URI: https://example.com/music-archiver
+ * Description: Albums, tracks, playlists, ratings, favourites, HTML5 player, Google Drive sync, and premium limits.
+ * Version: 1.0.0
+ * Author: OpenAI
+ * Author URI: https://example.com
+ * License: GPL-2.0-or-later
+ * Text Domain: music-archiver
+ * Requires at least: 6.6
+ * Requires PHP: 8.1
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! defined( 'MA_VERSION' ) ) {
+    define( 'MA_VERSION', '1.0.0' );
+}
+
+if ( ! defined( 'MA_PATH' ) ) {
+    define( 'MA_PATH', plugin_dir_path( __FILE__ ) );
+}
+
+if ( ! defined( 'MA_URL' ) ) {
+    define( 'MA_URL', plugin_dir_url( __FILE__ ) );
+}
+
+require_once MA_PATH . 'includes/helpers.php';
+require_once MA_PATH . 'includes/class-plugin.php';
+require_once MA_PATH . 'includes/class-activator.php';
+require_once MA_PATH . 'includes/class-deactivator.php';
+
+register_activation_hook( __FILE__, [ 'MA\\Activator', 'activate' ] );
+register_deactivation_hook( __FILE__, [ 'MA\\Deactivator', 'deactivate' ] );
+
+add_action( 'plugins_loaded', static function () {
+    load_plugin_textdomain( 'music-archiver', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
+
+    $plugin = new MA\Plugin();
+    $plugin->init();
+} );

--- a/music-archiver/public/css/music-archiver.css
+++ b/music-archiver/public/css/music-archiver.css
@@ -1,0 +1,77 @@
+.ma-player,
+.ma-playlist,
+.ma-album-card,
+.ma-ratings,
+.ma-favourites {
+    font-family: inherit;
+    color: var(--ma-text, #111);
+}
+
+.ma-player {
+    border: 1px solid #ccc;
+    padding: 1rem;
+    border-radius: 6px;
+    background: #fff;
+}
+
+.ma-player button,
+.ma-player input,
+.ma-player select {
+    font: inherit;
+}
+
+.ma-player button:focus,
+.ma-player input:focus,
+.ma-player select:focus,
+.ma-playlist button:focus {
+    outline: 2px solid #0073aa;
+    outline-offset: 2px;
+}
+
+.ma-playlist__items {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.ma-playlist__item {
+    display: flex;
+    justify-content: space-between;
+    padding: 0.5rem;
+    border-bottom: 1px solid #eee;
+}
+
+.ma-rating__stars button {
+    background: none;
+    border: 0;
+    font-size: 1.25rem;
+    cursor: pointer;
+}
+
+.ma-rating__stars button[aria-pressed="true"] {
+    color: #ffb300;
+}
+
+.ma-favourite__toggle {
+    background: none;
+    border: 0;
+    color: #e0245e;
+    font-size: 1.2rem;
+    cursor: pointer;
+}
+
+.ma-search-overlay {
+    position: relative;
+}
+
+.ma-search-overlay__results {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    background: #fff;
+    border: 1px solid #ccc;
+    max-height: 300px;
+    overflow-y: auto;
+    z-index: 1000;
+}

--- a/music-archiver/public/js/favourite.js
+++ b/music-archiver/public/js/favourite.js
@@ -1,0 +1,27 @@
+(function(){
+    const api = window.wp && window.wp.apiFetch;
+    const config = window.MAPlayer || {};
+    if (!api) {
+        return;
+    }
+
+    document.addEventListener('click', function(evt){
+        const button = evt.target.closest('[data-ma-favourite]');
+        if (!button) {
+            return;
+        }
+        evt.preventDefault();
+        const objectType = button.getAttribute('data-ma-favourite-type');
+        const objectId = button.getAttribute('data-ma-favourite-id');
+
+        api({
+            path: 'ma/v1/favourites/toggle',
+            method: 'POST',
+            headers: { 'X-WP-Nonce': config.nonce },
+            data: { object_type: objectType, object_id: objectId }
+        }).then(resp => {
+            const fav = resp.data.favourited;
+            button.setAttribute('aria-pressed', fav ? 'true' : 'false');
+        });
+    });
+})();

--- a/music-archiver/public/js/player.js
+++ b/music-archiver/public/js/player.js
@@ -1,0 +1,53 @@
+(function(){
+    const api = window.wp && window.wp.apiFetch;
+    const config = window.MAPlayer || {};
+    if (!api) {
+        return;
+    }
+
+    function fetchQueue(source) {
+        return api({
+            path: 'ma/v1/player/queue?source=' + encodeURIComponent(source),
+            headers: { 'X-WP-Nonce': config.nonce }
+        }).then(resp => resp.data.queue || []);
+    }
+
+    document.addEventListener('click', function(evt){
+        const target = evt.target.closest('[data-ma-player-load]');
+        if (!target) {
+            return;
+        }
+        evt.preventDefault();
+        const source = target.getAttribute('data-ma-player-load');
+        const container = document.querySelector('.ma-player');
+        if (!container) {
+            return;
+        }
+
+        fetchQueue(source).then(queue => {
+            if (!queue.length) {
+                return;
+            }
+            const audio = container.querySelector('audio');
+            const title = container.querySelector('[data-ma-player-title]');
+            let index = 0;
+
+            function playTrack(i) {
+                const track = queue[i];
+                if (!track) {
+                    return;
+                }
+                audio.src = track.source_url;
+                title.textContent = track.title;
+                audio.play();
+            }
+
+            audio.addEventListener('ended', function(){
+                index = (index + 1) % queue.length;
+                playTrack(index);
+            }, { once: false });
+
+            playTrack(index);
+        });
+    });
+})();

--- a/music-archiver/public/js/playlist.js
+++ b/music-archiver/public/js/playlist.js
@@ -1,0 +1,60 @@
+(function(){
+    const api = window.wp && window.wp.apiFetch;
+    const config = window.MAPlayer || {};
+    if (!api) {
+        return;
+    }
+
+    document.addEventListener('click', function(evt){
+        const button = evt.target.closest('[data-ma-playlist-add]');
+        if (!button) {
+            return;
+        }
+        evt.preventDefault();
+        const track = button.getAttribute('data-ma-playlist-add');
+        api({
+            path: 'ma/v1/playlist/items',
+            method: 'POST',
+            headers: { 'X-WP-Nonce': config.nonce },
+            data: { track_id: track }
+        });
+    });
+
+    const list = document.querySelector('[data-ma-playlist-sortable]');
+    if (!list) {
+        return;
+    }
+
+    let dragItem = null;
+    list.addEventListener('dragstart', function(evt){
+        dragItem = evt.target;
+        evt.dataTransfer.effectAllowed = 'move';
+    });
+
+    list.addEventListener('dragover', function(evt){
+        evt.preventDefault();
+        const target = evt.target.closest('[data-id]');
+        if (target && dragItem && target !== dragItem) {
+            const rect = target.getBoundingClientRect();
+            const next = (evt.clientY - rect.top) / (rect.bottom - rect.top) > 0.5;
+            list.insertBefore(dragItem, next ? target.nextSibling : target);
+        }
+    });
+
+    list.addEventListener('dragend', function(){
+        if (!dragItem) {
+            return;
+        }
+        const payload = Array.from(list.querySelectorAll('[data-id]')).map((item, index) => ({
+            id: item.getAttribute('data-id'),
+            position: index
+        }));
+        api({
+            path: 'ma/v1/playlist/order',
+            method: 'PATCH',
+            headers: { 'X-WP-Nonce': config.nonce },
+            data: payload
+        });
+        dragItem = null;
+    });
+})();

--- a/music-archiver/public/js/rating.js
+++ b/music-archiver/public/js/rating.js
@@ -1,0 +1,34 @@
+(function(){
+    const api = window.wp && window.wp.apiFetch;
+    const config = window.MAPlayer || {};
+    if (!api) {
+        return;
+    }
+
+    document.addEventListener('click', function(evt){
+        const button = evt.target.closest('[data-ma-rating]');
+        if (!button) {
+            return;
+        }
+        evt.preventDefault();
+        const wrapper = button.closest('[data-ma-rating-object]');
+        if (!wrapper) {
+            return;
+        }
+        const objectType = wrapper.getAttribute('data-ma-rating-object');
+        const objectId = wrapper.getAttribute('data-ma-rating-id');
+        const stars = button.getAttribute('data-ma-rating');
+
+        api({
+            path: 'ma/v1/ratings',
+            method: 'POST',
+            headers: { 'X-WP-Nonce': config.nonce },
+            data: { object_type: objectType, object_id: objectId, stars: stars }
+        }).then(() => {
+            wrapper.querySelectorAll('[data-ma-rating]').forEach(el => {
+                const pressed = el.getAttribute('data-ma-rating') === stars;
+                el.setAttribute('aria-pressed', pressed ? 'true' : 'false');
+            });
+        });
+    });
+})();

--- a/music-archiver/public/js/search.js
+++ b/music-archiver/public/js/search.js
@@ -1,0 +1,40 @@
+(function(){
+    const api = window.wp && window.wp.apiFetch;
+    const config = window.MAPlayer || {};
+    if (!api) {
+        return;
+    }
+
+    let timer = null;
+    document.addEventListener('input', function(evt){
+        const field = evt.target.closest('[data-ma-search]');
+        if (!field) {
+            return;
+        }
+        clearTimeout(timer);
+        const query = field.value;
+        timer = setTimeout(() => {
+            if (!query) {
+                return;
+            }
+            api({
+                path: 'ma/v1/search?q=' + encodeURIComponent(query),
+                headers: { 'X-WP-Nonce': config.nonce }
+            }).then(resp => {
+                const results = resp.data;
+                const list = field.parentElement.querySelector('.ma-search-overlay__results');
+                if (!list) {
+                    return;
+                }
+                list.innerHTML = '';
+                ['albums','tracks'].forEach(key => {
+                    (results[key] || []).forEach(item => {
+                        const li = document.createElement('div');
+                        li.textContent = item.name || item.title;
+                        list.appendChild(li);
+                    });
+                });
+            });
+        }, 200);
+    });
+})();

--- a/music-archiver/readme.txt
+++ b/music-archiver/readme.txt
@@ -1,0 +1,64 @@
+=== Music Archiver ===
+Contributors: openai
+Tags: music, playlist, audio, google-drive, premium
+Requires at least: 6.6
+Tested up to: 6.6
+Stable tag: 1.0.0
+Requires PHP: 8.1
+License: GPLv2 or later
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
+
+Music Archiver helps artists manage albums, tracks, playlists, ratings, favourites, HTML5 playback, premium upgrades, and Google Drive sync.
+
+== Description ==
+
+Music Archiver is an all-in-one toolkit for independent musicians and labels. Build albums, arrange tracks, publish playlists, collect ratings, save favourites, embed a responsive HTML5 player, and optionally sync audio from Google Drive. Premium limits can be enforced using Stripe Checkout or WooCommerce.
+
+== Installation ==
+
+1. Upload the plugin folder to `/wp-content/plugins/`.
+2. Activate the plugin through the "Plugins" menu.
+3. Visit **Settings → Music Archiver** to configure limits, premium mode, and Google Drive OAuth.
+
+== Features ==
+
+* Custom database tables for albums, tracks, playlists, ratings, favourites, and Drive links.
+* REST API (ma/v1) for CRUD, search, playlist ordering, premium status, and Drive sync.
+* Gutenberg blocks for Album List, Playlist, and Player.
+* Accessible HTML5 audio player with queue management.
+* Optional Google Drive integration with OAuth 2.0 and background sync.
+* Premium limits with Stripe Checkout or WooCommerce purchases.
+* GDPR-friendly data exporters and erasers.
+* Hooks for developers to extend behaviour.
+
+== Frequently Asked Questions ==
+
+= Does this plugin create custom post types? =
+Yes. Albums and Tracks can optionally be exposed as CPTs while primary data remains in custom tables.
+
+= How does premium mode work? =
+Choose Stripe or WooCommerce in settings. Users exceeding free limits are prompted to upgrade. Developers can filter limits using `ma_free_limits`.
+
+= What data is stored? =
+Albums, tracks, playlists, ratings, favourites, and optional Google Drive tokens. Tokens are encrypted using WordPress salts. Use the privacy exporter to review or erase.
+
+== Privacy ==
+
+The plugin stores user-generated music data and optional OAuth tokens for Google Drive. Tokens are encrypted at rest. Exporters and erasers are registered for compliance.
+
+== Developer Hooks ==
+
+* `do_action( 'ma_album_created', $album_id, $user_id )`
+* `do_action( 'ma_track_added', $track_id, $album_id )`
+* `apply_filters( 'ma_free_limits', [ 'albums' => 3, 'tracks_per_album' => 100 ] )`
+* `apply_filters( 'ma_player_queue', $queue, $source )`
+
+== Changelog ==
+
+= 1.0.0 =
+* Initial release.
+
+== Upgrade Notice ==
+
+= 1.0.0 =
+Initial release.

--- a/music-archiver/templates/album-card.php
+++ b/music-archiver/templates/album-card.php
@@ -1,0 +1,17 @@
+<?php
+/** @var array $albums */
+if ( empty( $albums ) ) :
+    echo '<p class="ma-album-card__empty">' . esc_html__( 'No albums found.', 'music-archiver' ) . '</p>';
+else :
+    echo '<div class="ma-album-card-list">';
+    foreach ( $albums as $album ) {
+        echo '<article class="ma-album-card">';
+        echo '<h3 class="ma-album-card__title">' . esc_html( $album['name'] ) . '</h3>';
+        if ( ! empty( $album['description'] ) ) {
+            echo '<p class="ma-album-card__description">' . wp_kses_post( $album['description'] ) . '</p>';
+        }
+        echo '<button class="ma-album-card__play" data-ma-player-load="album:' . esc_attr( $album['id'] ) . '">' . esc_html__( 'Play Album', 'music-archiver' ) . '</button>';
+        echo '</article>';
+    }
+    echo '</div>';
+endif;

--- a/music-archiver/templates/favourites.php
+++ b/music-archiver/templates/favourites.php
@@ -1,0 +1,10 @@
+<?php
+/** @var string $object */
+/** @var int $id */
+?>
+<div class="ma-favourites">
+    <button type="button" class="ma-favourite__toggle" aria-pressed="false" data-ma-favourite data-ma-favourite-type="<?php echo esc_attr( $object ); ?>" data-ma-favourite-id="<?php echo esc_attr( $id ); ?>">
+        ♥
+        <span class="screen-reader-text"><?php esc_html_e( 'Toggle favourite', 'music-archiver' ); ?></span>
+    </button>
+</div>

--- a/music-archiver/templates/player.php
+++ b/music-archiver/templates/player.php
@@ -1,0 +1,10 @@
+<?php
+/** @var string $source */
+?>
+<div class="ma-player" data-ma-player>
+    <div class="ma-player__now-playing">
+        <strong><?php esc_html_e( 'Now Playing:', 'music-archiver' ); ?></strong>
+        <span data-ma-player-title><?php esc_html_e( 'Select a track to start playback.', 'music-archiver' ); ?></span>
+    </div>
+    <audio controls preload="none" <?php echo $source ? 'data-ma-player-source="' . esc_attr( $source ) . '"' : ''; ?>></audio>
+</div>

--- a/music-archiver/templates/playlist.php
+++ b/music-archiver/templates/playlist.php
@@ -1,0 +1,7 @@
+<?php
+?>
+<div class="ma-playlist" data-ma-playlist>
+    <h3 class="ma-playlist__title"><?php esc_html_e( 'My Playlist', 'music-archiver' ); ?></h3>
+    <ul class="ma-playlist__items" data-ma-playlist-sortable>
+    </ul>
+</div>

--- a/music-archiver/templates/ratings.php
+++ b/music-archiver/templates/ratings.php
@@ -1,0 +1,14 @@
+<?php
+/** @var string $object */
+/** @var int $id */
+?>
+<div class="ma-ratings" data-ma-rating-object="<?php echo esc_attr( $object ); ?>" data-ma-rating-id="<?php echo esc_attr( $id ); ?>">
+    <div class="ma-rating__stars" role="group" aria-label="<?php esc_attr_e( 'Rate this item', 'music-archiver' ); ?>">
+        <?php for ( $i = 1; $i <= 5; $i++ ) : ?>
+            <button type="button" data-ma-rating="<?php echo esc_attr( $i ); ?>" aria-pressed="false">
+                <span class="screen-reader-text"><?php echo esc_html( sprintf( __( '%d star', 'music-archiver' ), $i ) ); ?></span>
+                ★
+            </button>
+        <?php endfor; ?>
+    </div>
+</div>

--- a/music-archiver/templates/track-row.php
+++ b/music-archiver/templates/track-row.php
@@ -1,0 +1,14 @@
+<?php
+/** @var array $track */
+?>
+<div class="ma-track-row" data-id="<?php echo esc_attr( $track['id'] ?? 0 ); ?>">
+    <span class="ma-track-row__title"><?php echo esc_html( $track['title'] ?? '' ); ?></span>
+    <div class="ma-track-row__actions">
+        <button type="button" class="ma-track-row__play" data-ma-player-load="track:<?php echo esc_attr( $track['id'] ?? 0 ); ?>">
+            <?php esc_html_e( 'Play', 'music-archiver' ); ?>
+        </button>
+        <button type="button" class="ma-track-row__playlist" data-ma-playlist-add="<?php echo esc_attr( $track['id'] ?? 0 ); ?>">
+            <?php esc_html_e( 'Add to playlist', 'music-archiver' ); ?>
+        </button>
+    </div>
+</div>

--- a/music-archiver/tests/bootstrap.php
+++ b/music-archiver/tests/bootstrap.php
@@ -1,0 +1,2 @@
+<?php
+// PHPUnit bootstrap placeholder.

--- a/music-archiver/tests/js/playlist-order.test.js
+++ b/music-archiver/tests/js/playlist-order.test.js
@@ -1,0 +1,20 @@
+const { test, expect } = require('node:test');
+
+test('playlist order payload', () => {
+    const items = [
+        { dataset: { id: '1' } },
+        { dataset: { id: '2' } },
+        { dataset: { id: '3' } },
+    ];
+
+    const payload = items.map((item, index) => ({
+        id: item.dataset.id,
+        position: index,
+    }));
+
+    expect(payload).toStrictEqual([
+        { id: '1', position: 0 },
+        { id: '2', position: 1 },
+        { id: '3', position: 2 },
+    ]);
+});

--- a/music-archiver/tests/phpunit.xml
+++ b/music-archiver/tests/phpunit.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<phpunit bootstrap="bootstrap.php" colors="true">
+    <testsuites>
+        <testsuite name="Music Archiver">
+            <file>test-db-install.php</file>
+            <file>test-rest-permissions.php</file>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/music-archiver/tests/test-db-install.php
+++ b/music-archiver/tests/test-db-install.php
@@ -1,0 +1,22 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+final class MusicArchiver_DB_Test extends TestCase {
+    public function test_tables_defined(): void {
+        $tables = [
+            'ma_albums',
+            'ma_tracks',
+            'ma_album_track',
+            'ma_playlists',
+            'ma_playlist_items',
+            'ma_ratings',
+            'ma_favourites',
+            'ma_drive_accounts',
+            'ma_drive_links',
+        ];
+
+        foreach ( $tables as $table ) {
+            $this->assertStringContainsString( 'ma_', $table );
+        }
+    }
+}

--- a/music-archiver/tests/test-rest-permissions.php
+++ b/music-archiver/tests/test-rest-permissions.php
@@ -1,0 +1,8 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+final class MusicArchiver_REST_Test extends TestCase {
+    public function test_rest_namespace(): void {
+        $this->assertTrue( true );
+    }
+}

--- a/music-archiver/uninstall.php
+++ b/music-archiver/uninstall.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Uninstall handler for Music Archiver.
+ */
+
+defined( 'WP_UNINSTALL_PLUGIN' ) || exit;
+
+require_once __DIR__ . '/includes/helpers.php';
+require_once __DIR__ . '/includes/class-db.php';
+require_once __DIR__ . '/includes/class-settings.php';
+
+$settings = get_option( 'ma_settings', [] );
+$retain   = isset( $settings['retain_data'] ) ? (bool) $settings['retain_data'] : false;
+
+if ( $retain ) {
+    return;
+}
+
+MA\DB::maybe_drop_tables();
+
+// Remove options and user meta added by the plugin.
+delete_option( 'ma_settings' );
+delete_option( 'ma_drive_oauth_state' );
+
+$meta_keys = [ 'ma_is_premium' ];
+
+foreach ( $meta_keys as $key ) {
+    delete_metadata( 'user', 0, $key, '', true );
+}


### PR DESCRIPTION
## Summary
- add Music Archiver plugin bootstrap with activation, roles, database tables, and privacy helpers
- implement REST API endpoints, premium checks, Google Drive integration hooks, and admin settings UI
- provide front-end assets, Gutenberg blocks, templates, and basic test scaffolding for the plugin

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7fa00a964832b8216b53221d81a89